### PR TITLE
Fixed wrong references in DNS resolution functions

### DIFF
--- a/Lib/GCS/wrapper.py
+++ b/Lib/GCS/wrapper.py
@@ -346,14 +346,15 @@ class Wrapper:
 					result = a
 					break
 				else:
-					result = self.getCNAMEv2(str(a))
+					result = self.getCNAME(str(a))
 	
 		except BaseException as e:
 			result = None
 		if result is not None:
 			return str(result)
 		
-		return results
+		return result
+
 	@functools.lru_cache()
 	def checkIfCDN(self,dnsRecord):
 		result = False
@@ -459,11 +460,6 @@ class Wrapper:
 		self.checkSlot.cache_clear()
 		self.checkIfCdnIP.cache_clear()
 
-		 
-		 
-		 
-		 
-		
 
 if __name__=="__main__":
 	w = Wrapper()

--- a/akamai-audit.py
+++ b/akamai-audit.py
@@ -652,7 +652,7 @@ class Aggregator:
 				
 				if 'cnameTo' in hostname:
 					cname_defined = hostname['cnameTo']
-					cname_actual = str(self.getCNAME(host))
+				cname_actual = str(self.getCNAME(host))
 				
 				slot = None
 				# TODO: Not working properly

--- a/akamai-audit.py
+++ b/akamai-audit.py
@@ -229,7 +229,8 @@ class Aggregator:
 		contracts = self.wrapper.getContractNames()	
 		for contract in contracts['contracts']['items']:
 			products = self._getProducts(contract['contractId'])
-			
+			self.log.debug("Found contract: '{0}' - '{1}'".format(contract['contractId'][4:], contract['contractTypeName']))
+
 			new_row = {
 				'Contract_ID': contract['contractId'][4:],
 				'Contract_Name':contract['contractTypeName'],
@@ -390,6 +391,7 @@ class Aggregator:
 				None
 		"""
 		groupId = group['groupId']
+		groupName = group['groupName']
 
 		if 'contractIds' in group:	
 					
@@ -456,7 +458,7 @@ class Aggregator:
 						
 
 					
-		self.log.debug("Fetched configs for group: '{0}'".format(groupId[4:]))
+		self.log.debug("Fetched configs for group: '{0}' - '{1}'".format(groupId[4:], groupName))
 		return None
 
 	def printCPcodes(self):
@@ -650,14 +652,14 @@ class Aggregator:
 				
 				if 'cnameTo' in hostname:
 					cname_defined = hostname['cnameTo']
-				cname_actual = str(self.getCNAME(host))
+					cname_actual = str(self.getCNAME(host))
 				
 				slot = None
 				# TODO: Not working properly
 				if cname_actual == "None":
 					isAkamaized = "Unknown"
 					secureHostName = "Unknown"
-					# slot = "Unknown"
+					slot = "None"
 				else:
 					isAkamaized = self._isAkamaized(cname_actual)
 					secureHostName = self._isESSL(cname_actual)
@@ -720,6 +722,7 @@ class Aggregator:
 				if 'enrollments' in enrollment_results:
 					if len(enrollment_results['enrollments']) >0:
 						for i in enrollment_results['enrollments']:
+							self.log.info("Getting Enrollment ID '{0}'".format(str(i['location']).split('/')[4]))
 							Enrollment_ID = str(i['location']).split('/')[4]
 							
 							new_row = {
@@ -1363,9 +1366,3 @@ if __name__=="__main__":
 				parser.error('--domain is needed for HTTP-Archive.')
 
 	obj_agg.clear_cache()
-
-
-
-		
-	
-	


### PR DESCRIPTION
The failures caused by the wrong references were preventing from all the properties under the account to show up in the report.